### PR TITLE
Proper redirect for posts hosted by gh-pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -75,7 +75,10 @@ layout: default
         {% for post in site.posts offset:0 limit:6 %}
           {% if post.title %}
             <a href="{{ root_url }}{{ post.url }}" class="recent_item" style="background-image: url( {{ "/assets/img/" | prepend: site.baseurl | append : post.img}} )"><span>{{ post.title }}</span></a>
-          {% endif %}
+            <!--
+             <a href="{{ site.url }}{{site.baseurl}}{{ post.url }}" class="recent_item" style="background-image: url( {{ "/assets/img/" | prepend: site.baseurl | append : post.img}} )"><span>{{ post.title }}</span></a>
+             -->
+        {% endif %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
Hello Artem,

I am using your Bef template for my Jekyll blog and I ran into this issue where my recent posts where not redirecting properly. Upon inspection I noticed that you are anchoring root_url along with the post.url. Perhaps this works with someone who is using a registered domain name but I utilize gh-pages.

Consequently, the blog crashes everytime any recent post is clicked due to not being redirected properly. The commented out code is my fix for proper recent post redirection for those hosting their site on gh-pages. I believe there should be a note in either your readme or _config.yaml that tells the user that if they plan to host their site on gh-pages then they should either comment or delete the current active anchor and uncomment the fix.