### PR TITLE
Fix deprecation, make chapter-title clickable and fix links in post layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,11 @@ paginate_path: /page:num/
 
 # Build settings
 markdown: kramdown
-plugins:
+plugins_dir:
+  - jekyll-paginate
+  - jekyll-sitemap
+
+gems:
   - jekyll-paginate
   - jekyll-sitemap
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -74,7 +74,11 @@ layout: default
       <div class="recent_list">
         {% for post in site.posts offset:0 limit:6 %}
           {% if post.title %}
-            <a href="{{ root_url }}{{ post.url }}" class="recent_item" style="background-image: url( {{ "/assets/img/" | prepend: site.baseurl | append : post.img}} )"><span>{{ post.title }}</span></a>
+            <a href="{{ post.url | prepend: site.baseurl }}"
+              class="recent_item"
+              style="background-image: url( {{ "/assets/img/" | prepend: site.baseurl | append : post.img}} )">
+                <span>{{ post.title }}</span>
+            </a>
           {% endif %}
         {% endfor %}
       </div>

--- a/index.html
+++ b/index.html
@@ -6,12 +6,14 @@ layout: main
   <div class="chapter">
     <a href="{{post.url | prepend: site.baseurl}}">
       {% if post.img %}
-      <img src={{ "/assets/img/" | prepend: site.baseurl | append: post.img }} alt="{{post.title}}">
+        <img src={{ "/assets/img/" | prepend: site.baseurl | append: post.img }} alt="{{post.title}}">
       {% endif %}
     </a>
-    <div class="chapter_inner">
-      <p class="chapter_number">{{post.date | date: '%Y, %b %d'}}</p>
-      <h3 class="chapter_title">{{post.title}}</h3>
-    </div>
+    <a href="{{post.url | prepend: site.baseurl}}">
+      <div class="chapter_inner">
+        <p class="chapter_number">{{post.date | date: '%Y, %b %d'}}</p>
+        <h3 class="chapter_title">{{post.title}}</h3>
+      </div>
+    </a>
   </div>
 {% endfor %}


### PR DESCRIPTION
Changes in this PR

* Fix deprecation notices in jekyll 3.0.1
  > Deprecation: The 'plugins' configurationoption has been renamed to 'plugins_dir'. Please update your config file accordingly.
  > Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in your configuration file.

* Make the chapter title on index.html clickable.
* In the post layout: Switch to 'prepend: site.baseurl' as everywhere else on the site (I checked for `{{ root_url }}` and only found it there).