### PR TITLE
changing name for email input.  Formspree expects e-mail addresses to…

### DIFF
--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -12,10 +12,10 @@ permalink: /contact/
   <form action="https://formspree.io/{{site.email}}" method="post" class="form">
     <div class="message js-form-message"></div>
     <div class="form_group">
-        <input type="text" placeholder="Your name" name="_replyto" class="form-input" required>
+        <input type="text" placeholder="Your name" name="name" class="form-input" required>
     </div>
     <div class="form_group">
-        <input type="email" placeholder="Your e-mail" name="form_email" class="form-input" required>
+        <input type="email" placeholder="Your e-mail" name="_replyto" class="form-input" required>
     </div>
     <div class="form_group">
         <input type="tel" placeholder="Your phone" name="form_tel" class="form-input">


### PR DESCRIPTION
Looks like formspree is looking for _replyto or email for the input's name.  Right now, "Your name" is using _replyto, so when formspree validates the e-mail address, they are actually validating the person's name, which is likely not a correctly formatted address.