### PR TITLE
+ .chapters .chapter img {height: 100%}

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4014,6 +4014,7 @@ cite {
 
 .chapters .chapter img {
   width: 100%;
+  height: 100%
   vertical-align: middle;
   -webkit-transition: all 0.4s;
   transition: all 0.4s;


### PR DESCRIPTION
In ".chapters .chapter img" if height is not set as 100% AND if all the images do not have the same heights, then on main.html the post (image) rows look uneven due to different image heights.